### PR TITLE
Fix encoding of supplementary characters

### DIFF
--- a/src/Escaper.php
+++ b/src/Escaper.php
@@ -248,7 +248,7 @@ class Escaper
          * replace it with while grabbing the integer value of the character.
          */
         if (strlen($chr) > 1) {
-            $chr = $this->convertEncoding($chr, 'UTF-16BE', 'UTF-8');
+            $chr = $this->convertEncoding($chr, 'UTF-32BE', 'UTF-8');
         }
 
         $hex = bin2hex($chr);

--- a/src/Escaper.php
+++ b/src/Escaper.php
@@ -297,7 +297,7 @@ class Escaper
         if (strlen($chr) == 1) {
             $ord = ord($chr);
         } else {
-            $chr = $this->convertEncoding($chr, 'UTF-16BE', 'UTF-8');
+            $chr = $this->convertEncoding($chr, 'UTF-32BE', 'UTF-8');
             $ord = hexdec(bin2hex($chr));
         }
         return sprintf('\\%X ', $ord);

--- a/src/Escaper.php
+++ b/src/Escaper.php
@@ -281,7 +281,13 @@ class Escaper
             return sprintf('\\x%02X', ord($chr));
         }
         $chr = $this->convertEncoding($chr, 'UTF-16BE', 'UTF-8');
-        return sprintf('\\u%04s', strtoupper(bin2hex($chr)));
+        $hex = strtoupper(bin2hex($chr));
+        if (strlen($hex) <= 4) {
+            return sprintf('\\u%04s', $hex);
+        }
+        $highSurrogate = substr($hex, 0, 4);
+        $lowSurrogate = substr($hex, 4, 4);
+        return sprintf('\\u%04s\\u%04s', $highSurrogate, $lowSurrogate);
     }
 
     /**

--- a/test/EscaperTest.php
+++ b/test/EscaperTest.php
@@ -44,6 +44,8 @@ class EscaperTest extends \PHPUnit_Framework_TestCase
         '&'     => '&amp;',
         /* Characters beyond ASCII value 255 to unicode escape */
         'Ā'     => '&#x0100;',
+        /* Characters beyond Unicode BMP to unicode escape */
+        "\xF0\x90\x80\x80" => '&#x10000;',
         /* Immune chars excluded */
         ','     => ',',
         '.'     => '.',

--- a/test/EscaperTest.php
+++ b/test/EscaperTest.php
@@ -81,6 +81,8 @@ class EscaperTest extends \PHPUnit_Framework_TestCase
         '&'     => '\\x26',
         /* Characters beyond ASCII value 255 to unicode escape */
         'Ā'     => '\\u0100',
+        /* Characters beyond Unicode BMP to unicode escape */
+        "\xF0\x90\x80\x80" => '\\uD800\\uDC00',
         /* Immune chars excluded */
         ','     => ',',
         '.'     => '.',

--- a/test/EscaperTest.php
+++ b/test/EscaperTest.php
@@ -145,6 +145,8 @@ class EscaperTest extends \PHPUnit_Framework_TestCase
         '&'     => '\\26 ',
         /* Characters beyond ASCII value 255 to unicode escape */
         'Ā'     => '\\100 ',
+        /* Characters beyond Unicode BMP to unicode escape */
+        "\xF0\x90\x80\x80" => '\\10000 ',
         /* Immune chars excluded */
         ','     => '\\2C ',
         '.'     => '\\2E ',


### PR DESCRIPTION
Fixes #2.

This PR adds test for supplementary characters (using the first supplementary character, U+10000, as an example) for escapeHtmlAttr, escapeCss, and escapeJs. The tests all fail on the current master branch and pass with the included changes.
