### PR TITLE
Normalize null input behavior

### DIFF
--- a/src/Escaper.php
+++ b/src/Escaper.php
@@ -309,6 +309,8 @@ class Escaper
      */
     protected function toUtf8($string)
     {
+        $string = (string) $string;
+
         if ($this->getEncoding() === 'utf-8') {
             $result = $string;
         } else {

--- a/test/EscaperTest.php
+++ b/test/EscaperTest.php
@@ -163,6 +163,10 @@ class EscaperTest extends \PHPUnit_Framework_TestCase
         ' '     => '\\20 ',
     ];
 
+    /**
+     * @var Escaper
+     */
+    private $escaper;
 
     public function setUp()
     {
@@ -389,5 +393,14 @@ class EscaperTest extends \PHPUnit_Framework_TestCase
                 );
             }
         }
+    }
+
+    public function testEscapingReturnsStringIfNull()
+    {
+        $this->assertEquals('', $this->escaper->escapeHtml(null));
+        $this->assertEquals('', $this->escaper->escapeUrl(null));
+        $this->assertEquals('', $this->escaper->escapeCss(null));
+        $this->assertEquals('', $this->escaper->escapeJs(null));
+        $this->assertEquals('', $this->escaper->escapeHtmlAttr(null));
     }
 }


### PR DESCRIPTION
This PR normalizes the behavior for null or not string inputs. 
`escapeHtml()` and `escapeUrl()` are using a implicit string cast so `$escaper->escapeHtml(null)` and `$escaper->escapeUrl(null)` will return an empty string.

`$escaper->escapeCss/escapeJs/escapeHtmlAttr(null)` will throw the following Exception instead: 

`Zend\Escaper\Exception\RuntimeException: String to be escaped was not valid UTF-8 or could not be converted`.

With this PR all inputs will be casted to a string so the behavior of all methods is consistent. 
