### PR TITLE
Add the link to the docs in the composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,5 +31,8 @@
     "require-dev": {
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0"
+    },
+    "support": {
+        "docs": "https://zendframework.github.io/zend-escaper/"
     }
 }


### PR DESCRIPTION
The `support` section of the composer.json allows to provide info about several support channels (see https://getcomposer.org/doc/04-schema.md#support for the full list)

As the docs are available online, I'm adding the link here, allowing automated tools to benefit from the info. for instance, Packagist displays a link to the documentation when it knows it (sreenshot is for a different package, as zend-escaper will obviously not have this link yet as the PR is not merged): 
![packagist_doc](https://cloud.githubusercontent.com/assets/439401/25950482/71ae8c7e-365b-11e7-9bbb-1b7592977539.png)

I'm not adding the issue tracker here, because composer already adds it automatically for github repositories (when calling the API, it checks whether issues are enabled on the repo, and then injects the link to the issue tracker in the support section if there is none provided). The automated injection is better, as it is updated automatically if you rename the github repo.
If you have extra support channels (IRC, mailing-list, forum, etc...), I will let you improve the metadata further.