### PR TITLE
A simple invalid 2 octet sequence can cause an exception (which then …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- Default behavior changed when malformed is pushed into toUtf8.  Rather than dumping the bad string in an exception (dangerous behavior), it will return a blank string.
+- Boolean 'debug' parameter added as second constructor argument, that preserves the old behavior when set to true. 
 
 ### Deprecated
 

--- a/src/Escaper.php
+++ b/src/Escaper.php
@@ -86,13 +86,20 @@ class Escaper
     ];
 
     /**
+     * Set debug mode to true to identify critical failures that you may want to mask during production.
+     * @var bool
+     */
+    private $debug;
+
+    /**
      * Constructor: Single parameter allows setting of global encoding for use by
      * the current object.
      *
      * @param string $encoding
+     * @param bool $debug
      * @throws Exception\InvalidArgumentException
      */
-    public function __construct($encoding = null)
+    public function __construct($encoding = null, $debug = false)
     {
         if ($encoding !== null) {
             $encoding = (string) $encoding;
@@ -111,6 +118,7 @@ class Escaper
             }
 
             $this->encoding = $encoding;
+            $this->debug = $debug;
         }
 
         // We take advantage of ENT_SUBSTITUTE flag to correctly deal with invalid UTF-8 sequences.
@@ -322,6 +330,10 @@ class Escaper
         }
 
         if (!$this->isUtf8($result)) {
+            if (!$this->debug) {
+                return '';
+            }
+
             throw new Exception\RuntimeException(
                 sprintf('String to be escaped was not valid UTF-8 or could not be converted: %s', $result)
             );

--- a/test/EscaperTest.php
+++ b/test/EscaperTest.php
@@ -10,6 +10,7 @@
 namespace ZendTest\Escaper;
 
 use Zend\Escaper\Escaper;
+use Zend\Escaper\Exception\RuntimeException;
 
 class EscaperTest extends \PHPUnit_Framework_TestCase
 {
@@ -395,5 +396,34 @@ class EscaperTest extends \PHPUnit_Framework_TestCase
                 );
             }
         }
+    }
+
+    /**
+     * Under 'standard' operation, we can't have the Escaper dumping attack vectors into templates
+     * @throws \ReflectionException
+     */
+    public function testWillInsulateAgainstMalformedInput()
+    {
+        $reflection = new \ReflectionClass(get_class($this->escaper));
+        $method = $reflection->getMethod('toUtf8');
+        $method->setAccessible(true);
+        $this->assertSame(
+            '',
+            $method->invokeArgs($this->escaper, ["\xc3\x28"])
+        );
+    }
+
+    /**
+     * Under 'standard' operation, we can't have the Escaper dumping attack vectors into templates
+     * @throws \ReflectionException
+     * @expectedException RuntimeException
+     */
+    public function testWillReportMalformedInputInDebugMode()
+    {
+        $this->escaper = new Escaper('utf-8', true);
+        $reflection = new \ReflectionClass(get_class($this->escaper));
+        $method = $reflection->getMethod('toUtf8');
+        $method->setAccessible(true);
+        $method->invokeArgs($this->escaper, ["\xc3\x28"]);
     }
 }


### PR DESCRIPTION
A change is necessary to prevent routine penetration tests, or user-land attacks from causing critical exceptions. Users shouldn't be able to craft malicious input that causes 500s when using components such as Zend Form.

Did my best to eyeball formatting conventions, phpcs is in a panic with the given config.

Debug added as second arg to ctor; but could separately be moved into (or complemented by) a setDebug method.